### PR TITLE
Speed up png to rawimg conversion with pointers

### DIFF
--- a/src/TML.Files/Extraction/Packers/PngFilePacker.cs
+++ b/src/TML.Files/Extraction/Packers/PngFilePacker.cs
@@ -31,8 +31,8 @@ public class PngFilePacker : BaseFilePacker
         writer.Write(image.Height);
         int totalPixels = image.Width * image.Height;
 
-        if (to.Length < totalPixels) {
-            to.SetLength(totalPixels);
+        if (to.Capacity < totalPixels) {
+            to.Capacity = totalPixels;
         }
 
         if (to.TryGetBuffer(out ArraySegment<byte> buffer) && buffer.Count >= totalPixels && image.DangerousTryGetSinglePixelMemory(out var memory)) {

--- a/src/TML.Files/Extraction/Packers/PngFilePacker.cs
+++ b/src/TML.Files/Extraction/Packers/PngFilePacker.cs
@@ -31,8 +31,8 @@ public class PngFilePacker : BaseFilePacker
         writer.Write(image.Height);
         int totalPixels = image.Width * image.Height;
 
-        if (to.Length < from.Length) {
-            to.SetLength(from.Length);
+        if (to.Length < totalPixels) {
+            to.SetLength(totalPixels);
         }
 
         if (to.TryGetBuffer(out ArraySegment<byte> buffer) && buffer.Count >= totalPixels && image.DangerousTryGetSinglePixelMemory(out var memory)) {

--- a/src/TML.Files/Extraction/Packers/PngFilePacker.cs
+++ b/src/TML.Files/Extraction/Packers/PngFilePacker.cs
@@ -39,11 +39,11 @@ public class PngFilePacker : BaseFilePacker
             fixed (byte* _ptr = buffer.Array!)
             fixed (Rgba32* _colorPtr = memory.Span)
             {
-                int* dst = (int*)(_ptr + buffer.Offset);
-                int* src = (int*)_colorPtr;
+                uint* dst = (uint*)(_ptr + buffer.Offset);
+                uint* src = (uint*)_colorPtr;
                 for (nint i = 0, c = totalPixels / 4; i < c; i++) {
-                    int col = src[i];
-                    dst[i] = col == 0 ? 0 : col;
+                    uint col = src[i];
+                    dst[i] = (col & 0xFF) == 0 ? 0 : col;
                 }
             }
             GC.KeepAlive(image);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56768047/221404613-1dd731e9-9d30-466c-b811-a99650c7f299.png)
Benchmark code:
```cs
using System;
using System.IO;
using System.Linq;
using BenchmarkDotNet;
using BenchmarkDotNet.Analysers;
using BenchmarkDotNet.Attributes;
using BenchmarkDotNet.Diagnosers;
using BenchmarkDotNet.Running;
using SixLabors.ImageSharp;
using SixLabors.ImageSharp.PixelFormats;

BenchmarkRunner.Run<PointerConversionTest>();

[MemoryDiagnoser]
public class PointerConversionTest 
{
    List<Image<Rgba32>> images;
    public PointerConversionTest()
    {
        var config= Configuration.Default.Clone();
        config.PreferContiguousImageBuffers = true;
        images = Directory.EnumerateFiles("images").Select(file => Image.Load<Rgba32>(config, file)).AsParallel().AsUnordered().ToList();
    }
    [Benchmark]
    public void TestNormal()
    {
        foreach(var img in images)
        {
            Convert1(img, new MemoryStream());
        }
    }
    [Benchmark]
    public void TestPointer()
    {
        foreach(var img in images)
        {
            Convert2(img, new MemoryStream());
        }
    }
    void Convert1(Image<Rgba32> image, MemoryStream to)
    {
        for (int y = 0; y < image.Height; y++)
        {
            for (int x = 0; x < image.Width; x++)
            {
                Rgba32 color = image[x, y];

                if (color.A == 0) color = new Rgba32(0, 0, 0, 0);
                to.WriteByte(color.R);
                to.WriteByte(color.G);
                to.WriteByte(color.B);
                to.WriteByte(color.A);
            }
        }
    }
    unsafe void Convert2(Image<Rgba32> image, MemoryStream to)
    {
        int totalPixels = image.Width * image.Height;
        if (to.Capacity < totalPixels)
            to.Capacity = totalPixels;
        if (!to.TryGetBuffer(out var buffer) || !image.DangerousTryGetSinglePixelMemory(out var memory))
            throw new Exception("Failure to get buffer or pixel memory");
        byte[] b = buffer.Array!;
        fixed (byte* _ptr = b)
        fixed (Rgba32* _colorPtr = memory.Span)
        {
            int* ptr = (int*)(_ptr + buffer.Offset);
            int* colorPtr = (int*)_colorPtr;
            for (nint i = 0, c = totalPixels / 4; i < c; i++)
            {
                int col = colorPtr[i];
				ptr[i] = col == 0 ? 0 : col;
            }
        }
    }
}